### PR TITLE
Update / Fix out of date sources

### DIFF
--- a/binutils/meta.yaml
+++ b/binutils/meta.yaml
@@ -21,6 +21,7 @@ build:
 
 requirements:
   build:
+   - texinfo
    - {{ compiler('c') }}
   run:
   {% for package in resolved_packages('host') %}

--- a/binutils/meta.yaml
+++ b/binutils/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '2.32' %}
+{% set version = '2.34' %}
 
 package:
   name: binutils-{{ environ.get('TOOLCHAIN_ARCH') }}-elf
@@ -7,12 +7,12 @@ package:
 source:
   fn: binutils-{{ version }}.tar.bz2
   url: https://ftp.gnu.org/gnu/binutils/binutils-{{ version }}.tar.xz
-  sha256: 0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
+  sha256: f00b0e8803dc9bab1e2165bd568528135be734df3fabf8d0161828cd56028952
 
 build:
-  # number: 201803050325
+  # number: 202002272218
   number: {{ environ.get('DATE_NUM') }}
-  # string: 20180305_0325
+  # string: 20200227_2218
   string: {{ environ.get('DATE_STR') }}
   script_env:
     - CI

--- a/gcc/linux-musl/meta.yaml
+++ b/gcc/linux-musl/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '9.1.0' %}
+{% set version = '9.2.0' %}
 {% set binutilsversion = '2.34' %}
 
 package:
@@ -15,7 +15,7 @@ source:
     folder: kernel-headers
   - url: http://ftp.gnu.org/gnu/gcc/gcc-{{ version }}/gcc-{{ version }}.tar.xz
     fn: gcc-{{ version }}.tar.gz
-    sha256: 79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0
+    sha256: ea6ef08f121239da5695f76c9b33637a118dcf63e24164422231917fa61fb206
     folder: gcc
   - git_url: git://git.musl-libc.org/musl
     git_rev: ac304227bb3ea1787d581f17d76a5f5f3abff51f

--- a/gcc/linux-musl/meta.yaml
+++ b/gcc/linux-musl/meta.yaml
@@ -46,6 +46,7 @@ build:
 
 requirements:
   build:
+    - texinfo
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:

--- a/gcc/linux-musl/meta.yaml
+++ b/gcc/linux-musl/meta.yaml
@@ -1,13 +1,14 @@
 {% set version = '9.1.0' %}
+{% set binutilsversion = '2.34' %}
 
 package:
   name: gcc-{{ environ.get('TOOLCHAIN_ARCH') }}-linux-musl
   version: {{ version }}
 
 source:
-  - url: https://ftp.gnu.org/gnu/binutils/binutils-2.32.tar.xz
-    fn: binutils-2.32.tar.bz2
-    sha256: 0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
+  - url: https://ftp.gnu.org/gnu/binutils/binutils-{{ binutilsversion }}.tar.xz
+    fn: binutils-{{ binutilsversion }}.tar.bz2
+    sha256: f00b0e8803dc9bab1e2165bd568528135be734df3fabf8d0161828cd56028952
     folder: binutils
   - git_url: https://github.com/mithro/kernel-headers.git
     git_rev: master

--- a/gcc/newlib/meta.yaml
+++ b/gcc/newlib/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '9.1.0' %}
+{% set version = '9.2.0' %}
 
 package:
   name: gcc-{{ environ.get('TOOLCHAIN_ARCH') }}-elf-newlib
@@ -7,11 +7,11 @@ package:
 source:
   - url: http://ftp.gnu.org/gnu/gcc/gcc-{{ version }}/gcc-{{ version }}.tar.xz
     fn: gcc-{{ version }}.tar.gz
-    sha256: 79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0
+    sha256: ea6ef08f121239da5695f76c9b33637a118dcf63e24164422231917fa61fb206
     folder: gcc
-  - url: http://sourceware.org/pub/newlib/newlib-3.1.0.tar.gz
-    fn: newlib-3.0.0.20180831.tar.gz
-    sha256: fb4fa1cc21e9060719208300a61420e4089d6de6ef59cf533b57fe74801d102a
+  - url: http://sourceware.org/pub/newlib/newlib-3.3.0.tar.gz
+    fn: newlib-3.3.0.tar.gz
+    sha256: 58dd9e3eaedf519360d92d84205c3deef0b3fc286685d1c562e245914ef72c66
     folder: newlib
 
 build:

--- a/gcc/nostdc/meta.yaml
+++ b/gcc/nostdc/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '9.1.0' %}
+{% set version = '9.2.0' %}
 
 package:
   name: gcc-{{ environ.get('TOOLCHAIN_ARCH') }}-elf-nostdc
@@ -7,7 +7,7 @@ package:
 source:
   - url: http://ftp.gnu.org/gnu/gcc/gcc-{{ version }}/gcc-{{ version }}.tar.xz
     fn: gcc-{{ version }}.tar.gz
-    sha256: 79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0
+    sha256: ea6ef08f121239da5695f76c9b33637a118dcf63e24164422231917fa61fb206
     folder: gcc
 
 build:

--- a/gdb/meta.yaml
+++ b/gdb/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '8.3.1' %}
+{% set version = '9.1' %}
 
 package:
   name: gdb-{{ environ.get('TOOLCHAIN_ARCH') }}-elf
@@ -7,7 +7,7 @@ package:
 source:
   fn: gdb-{{ version }}.tar.xz
   url: http://ftp.gnu.org/gnu/gdb/gdb-{{ version }}.tar.xz
-  sha256: 1e55b4d7cdca7b34be12f4ceae651623aa73b2fd640152313f9f66a7149757c4
+  sha256: 699e0ec832fdd2f21c8266171ea5bf44024bd05164fdf064e4d10cc4cf0d1737
 
 build:
   detect_binary_files_with_prefix: True

--- a/prog/icefunprog/meta.yaml
+++ b/prog/icefunprog/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  git_url: https://github.com/y2kbugger/iceFUNprog.git
+  git_url: https://github.com/devantech/iceFUNprog.git
   git_rev: master
 
 build:

--- a/prog/icefunprog/meta.yaml
+++ b/prog/icefunprog/meta.yaml
@@ -1,4 +1,8 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG or 'v0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(
+    environ.get('GIT_DESCRIBE_TAG', 'v0.X'),
+    environ.get('GIT_DESCRIBE_NUMBER', '0')|int,
+    environ.get('GIT_DESCRIBE_HASH', 'gUNKNOWN')
+    ) %}
 
 package:
   name: icefunprog

--- a/toolchain/linux-musl/0001-quieter-tar.patch
+++ b/toolchain/linux-musl/0001-quieter-tar.patch
@@ -1,0 +1,31 @@
+diff --git a/Makefile b/Makefile
+index 261506c..b7dc423 100644
+--- a/Makefile
++++ b/Makefile
+@@ -117,7 +117,7 @@ musl-riscv-%:
+ 	case "$@" in */*) exit 1 ;; esac
+ 	rm -rf $@.tmp
+ 	mkdir $@.tmp
+-	( cd $@.tmp && tar zxvf - ) < $<
++	( cd $@.tmp && tar zxf - ) < $<
+ 	rm -rf $@
+ 	touch $@.tmp/$(patsubst %.orig,%,$@)
+ 	mv $@.tmp/$(patsubst %.orig,%,$@) $@
+@@ -127,7 +127,7 @@ musl-riscv-%:
+ 	case "$@" in */*) exit 1 ;; esac
+ 	rm -rf $@.tmp
+ 	mkdir $@.tmp
+-	( cd $@.tmp && tar jxvf - ) < $<
++	( cd $@.tmp && tar jxf - ) < $<
+ 	rm -rf $@
+ 	touch $@.tmp/$(patsubst %.orig,%,$@)
+ 	mv $@.tmp/$(patsubst %.orig,%,$@) $@
+@@ -137,7 +137,7 @@ musl-riscv-%:
+ 	case "$@" in */*) exit 1 ;; esac
+ 	rm -rf $@.tmp
+ 	mkdir $@.tmp
+-	( cd $@.tmp && tar Jxvf - ) < $<
++	( cd $@.tmp && tar Jxf - ) < $<
+ 	rm -rf $@
+ 	touch $@.tmp/$(patsubst %.orig,%,$@)
+ 	mv $@.tmp/$(patsubst %.orig,%,$@) $@

--- a/toolchain/linux-musl/meta.yaml
+++ b/toolchain/linux-musl/meta.yaml
@@ -3,8 +3,10 @@ package:
   version: {{ environ.get('GITREV').replace('-', '_') }}
 
 source:
-  - git_url: https://git.zv.io/toolchains/musl-cross-make.git
-    git_rev: master
+  git_url: https://git.zv.io/toolchains/musl-cross-make.git
+  git_rev: master
+  patches:
+    - 0001-quieter-tar.patch
 
 build:
   # number: 201803050325

--- a/toolchain/linux-musl/meta.yaml
+++ b/toolchain/linux-musl/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   - git_url: https://git.zv.io/toolchains/musl-cross-make.git
-    git_rev: musl-git
+    git_rev: master
 
 build:
   # number: 201803050325


### PR DESCRIPTION
Update binutils 2.32 --> 2.34
Update gcc 9.1.0 --> 9.2.0
Fixed moved sources
Pointed IceFUNprog to upstream since they have merged makefiles, etc.